### PR TITLE
Add tests for comment routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,6 @@ const LocalStrategy = require('passport-local').Strategy;
 
 const pool = new Pool();
 const app = express();
-const port = 3000;
 
 app.get('/', async (req, res) => res.send("Hello world!"));
 
@@ -111,7 +110,4 @@ app.post('/v1/user', async (req, res, next) => {
 //app.put('/v1/user')
 //app.delete('/v1/user/:id')
 
-
-app.listen(port, () => console.log(`Example app listening on port ${port}.`));
-
-exports.server = app;
+exports.app = app;

--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ app.get('/v1/comment/:id', async (req, res, next) => {
 
 app.post('/v1/comment', async (req, res, next) => {
     try {
-        const queryResult = await pool.query("INSERT INTO comments(thread_id, parent_id, user_id, content) VALUES($1, $2, $3, $4)", 
+        const queryResult = await pool.query("INSERT INTO comments(thread_id, parent_id, user_id, content) VALUES($1, $2, $3, $4)",
             [
                 req.body["thread_id"],
                 req.body["parent_id"],
@@ -94,7 +94,7 @@ app.get('/v1/user/:id', async (req, res, next) => {
 });
 app.post('/v1/user', async (req, res, next) => {
     try {
-        const queryResult = await pool.query("INSERT INTO users(email_or_id, display_name, website, encrypted_password) VALUES($1, $2, $3, $4)", 
+        const queryResult = await pool.query("INSERT INTO users(email_or_id, display_name, website, encrypted_password) VALUES($1, $2, $3, $4)",
             [
                 req.body["email_or_id"],
                 req.body["display_name"],
@@ -113,3 +113,5 @@ app.post('/v1/user', async (req, res, next) => {
 
 
 app.listen(port, () => console.log(`Example app listening on port ${port}.`));
+
+exports.server = app;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+const { app } = require('./app');
+
+const port = 3000;
+
+app.listen(port, () => console.log(`Example app listening on port ${port}.`));

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,207 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/core": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz",
+            "integrity": "sha512-jRsuseXBo9pN197KnDwhhaaBzyZr2oIcLHHTt2oDdQrej5Qp57dCCJafWx5ivU8/alEYDpssYqv1MUqcxwQlrA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.3.4",
+                "@babel/helpers": "^7.2.0",
+                "@babel/parser": "^7.3.4",
+                "@babel/template": "^7.2.2",
+                "@babel/traverse": "^7.3.4",
+                "@babel/types": "^7.3.4",
+                "convert-source-map": "^1.1.0",
+                "debug": "^4.1.0",
+                "json5": "^2.1.0",
+                "lodash": "^4.17.11",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+            "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "dev": true
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+            "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
+            "integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.1.2",
+                "@babel/traverse": "^7.1.5",
+                "@babel/types": "^7.3.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+            "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
+            "dev": true
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+            "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/template": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+            "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.2.2",
+                "@babel/types": "^7.2.2"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+            "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.3.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.3.4",
+                "@babel/types": "^7.3.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+            "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "abab": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+            "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+            "dev": true
+        },
         "accepts": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -13,10 +214,312 @@
                 "negotiator": "0.6.1"
             }
         },
+        "acorn": {
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+            "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+            "dev": true
+        },
+        "acorn-globals": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+            "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+            "dev": true,
+            "requires": {
+                "acorn": "^6.0.1",
+                "acorn-walk": "^6.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+                    "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+                    "dev": true
+                }
+            }
+        },
+        "acorn-walk": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+            "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
+            "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-escapes": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+            "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "anymatch": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "dev": true,
+            "requires": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+            }
+        },
+        "append-transform": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+            "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+            "dev": true,
+            "requires": {
+                "default-require-extensions": "^2.0.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "arr-diff": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+            "dev": true
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+            "dev": true
+        },
         "array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "array-unique": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+            "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.11"
+            }
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+            "dev": true
+        },
+        "babel-jest": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.1.0.tgz",
+            "integrity": "sha512-MLcagnVrO9ybQGLEfZUqnOzv36iQzU7Bj4elm39vCukumLVSfoX+tRy3/jW7lUKc7XdpRmB/jech6L/UCsSZjw==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-istanbul": "^5.1.0",
+                "babel-preset-jest": "^24.1.0",
+                "chalk": "^2.4.2",
+                "slash": "^2.0.0"
+            }
+        },
+        "babel-plugin-istanbul": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
+            "integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "istanbul-lib-instrument": "^3.0.0",
+                "test-exclude": "^5.0.0"
+            }
+        },
+        "babel-plugin-jest-hoist": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.1.0.tgz",
+            "integrity": "sha512-gljYrZz8w1b6fJzKcsfKsipSru2DU2DmQ39aB6nV3xQ0DDv3zpIzKGortA5gknrhNnPN8DweaEgrnZdmbGmhnw==",
+            "dev": true
+        },
+        "babel-preset-jest": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.1.0.tgz",
+            "integrity": "sha512-FfNLDxFWsNX9lUmtwY7NheGlANnagvxq8LZdl5PKnVG3umP+S/g0XbVBfwtA4Ai3Ri/IMkWabBz3Tyk9wdspcw==",
+            "dev": true,
+            "requires": {
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                "babel-plugin-jest-hoist": "^24.1.0"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
         },
         "body-parser": {
             "version": "1.18.3",
@@ -35,6 +538,83 @@
                 "type-is": "~1.6.16"
             }
         },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "browser-process-hrtime": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+            "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+            "dev": true
+        },
+        "browser-resolve": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+            "dev": true,
+            "requires": {
+                "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "bser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "dev": true,
+            "requires": {
+                "node-int64": "^0.4.0"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
         "buffer-writer": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
@@ -44,6 +624,189 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
             "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+            }
+        },
+        "callsites": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+            "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+            "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+            "dev": true
+        },
+        "capture-exit": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+            "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+            "dev": true,
+            "requires": {
+                "rsvp": "^3.3.3"
+            }
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "ci-info": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "dev": true
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "cliui": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.17.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+            "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+            "dev": true,
+            "optional": true
+        },
+        "compare-versions": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+            "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "content-disposition": {
             "version": "0.5.2",
@@ -55,6 +818,15 @@
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
         },
+        "convert-source-map": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -65,6 +837,93 @@
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
+        "cookiejar": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+            "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+            "dev": true
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "dev": true,
+            "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "dev": true
+                }
+            }
+        },
+        "cssom": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+            "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+            "integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+            "dev": true,
+            "requires": {
+                "cssom": "0.3.x"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "data-urls": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+            "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.0",
+                "whatwg-mimetype": "^2.2.0",
+                "whatwg-url": "^7.0.0"
+            },
+            "dependencies": {
+                "whatwg-url": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+                    "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.sortby": "^4.7.0",
+                        "tr46": "^1.0.1",
+                        "webidl-conversions": "^4.0.2"
+                    }
+                }
+            }
+        },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -72,6 +931,89 @@
             "requires": {
                 "ms": "2.0.0"
             }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "default-require-extensions": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+            "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+            "dev": true,
+            "requires": {
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
         },
         "depd": {
             "version": "1.1.2",
@@ -83,6 +1025,37 @@
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
         },
+        "detect-newline": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+            "dev": true
+        },
+        "diff-sequences": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.0.0.tgz",
+            "integrity": "sha512-46OkIuVGBBnrC0soO/4LHu5LHGHx0uhP65OVz8XOrAJpqiCB2aVIuESvjI1F9oqebuvY8lekS1pt6TN7vt7qsw==",
+            "dev": true
+        },
+        "domexception": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+            "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "^4.0.2"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -93,15 +1066,188 @@
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "escodegen": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+            "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+            "dev": true,
+            "requires": {
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
         "etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+        },
+        "exec-sh": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+            "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+            "dev": true,
+            "requires": {
+                "merge": "^1.2.0"
+            }
+        },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            }
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
+        "expand-brackets": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "expect": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-24.1.0.tgz",
+            "integrity": "sha512-lVcAPhaYkQcIyMS+F8RVwzbm1jro20IG8OkvxQ6f1JfqhVZyyudCwYogQ7wnktlf14iF3ii7ArIUO/mqvrW9Gw==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "jest-get-type": "^24.0.0",
+                "jest-matcher-utils": "^24.0.0",
+                "jest-message-util": "^24.0.0",
+                "jest-regex-util": "^24.0.0"
+            }
         },
         "express": {
             "version": "4.16.4",
@@ -140,6 +1286,164 @@
                 "vary": "~1.1.2"
             }
         },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
+            "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "extglob": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+            "dev": true,
+            "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fb-watchman": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+            "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+            "dev": true,
+            "requires": {
+                "bser": "^2.0.0"
+            }
+        },
+        "fileset": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+            "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.3",
+                "minimatch": "^3.0.3"
+            }
+        },
+        "fill-range": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
         "finalhandler": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -154,15 +1458,769 @@
                 "unpipe": "~1.0.0"
             }
         },
+        "find-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "dev": true,
+            "requires": {
+                "locate-path": "^3.0.0"
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "formidable": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+            "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+            "dev": true
+        },
         "forwarded": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
             "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
         },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "^0.2.2"
+            }
+        },
         "fresh": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fsevents": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+            "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chownr": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minipass": {
+                    "version": "2.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "needle": {
+                    "version": "2.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.10.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.1",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.2.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "^0.6.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "semver": {
+                    "version": "5.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "4.4.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wide-align": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "^1.0.2 || 2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "dev": true,
+            "requires": {
+                "pump": "^3.0.0"
+            }
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "globals": {
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+            "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+            "dev": true
+        },
+        "growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+            "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+            "dev": true,
+            "requires": {
+                "async": "^2.5.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "dev": true
+        },
+        "html-encoding-sniffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+            "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "^1.0.1"
+            }
         },
         "http-errors": {
             "version": "1.6.3",
@@ -175,6 +2233,17 @@
                 "statuses": ">= 1.4.0 < 2"
             }
         },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
         "iconv-lite": {
             "version": "0.4.23",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
@@ -183,30 +2252,1100 @@
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
+        "import-local": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+            "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+            "dev": true,
+            "requires": {
+                "pkg-dir": "^3.0.0",
+                "resolve-cwd": "^2.0.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "invert-kv": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+            "dev": true
         },
         "ipaddr.js": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
             "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
         },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
+        },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "dev": true
+        },
+        "is-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
+            "requires": {
+                "ci-info": "^2.0.0"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-generator-fn": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
+            "integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
+            "dev": true
+        },
+        "is-number": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.1"
+            }
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.0"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "istanbul-api": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
+            "integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+            "dev": true,
+            "requires": {
+                "async": "^2.6.1",
+                "compare-versions": "^3.2.1",
+                "fileset": "^2.0.3",
+                "istanbul-lib-coverage": "^2.0.3",
+                "istanbul-lib-hook": "^2.0.3",
+                "istanbul-lib-instrument": "^3.1.0",
+                "istanbul-lib-report": "^2.0.4",
+                "istanbul-lib-source-maps": "^3.0.2",
+                "istanbul-reports": "^2.1.1",
+                "js-yaml": "^3.12.0",
+                "make-dir": "^1.3.0",
+                "minimatch": "^3.0.4",
+                "once": "^1.4.0"
+            }
+        },
+        "istanbul-lib-coverage": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+            "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+            "dev": true
+        },
+        "istanbul-lib-hook": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+            "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+            "dev": true,
+            "requires": {
+                "append-transform": "^1.0.0"
+            }
+        },
+        "istanbul-lib-instrument": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+            "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+            "dev": true,
+            "requires": {
+                "@babel/generator": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "istanbul-lib-coverage": "^2.0.3",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+            "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^2.0.3",
+                "make-dir": "^1.3.0",
+                "supports-color": "^6.0.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+            "integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.3",
+                "make-dir": "^1.3.0",
+                "rimraf": "^2.6.2",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-reports": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+            "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+            "dev": true,
+            "requires": {
+                "handlebars": "^4.1.0"
+            }
+        },
+        "jest": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-24.1.0.tgz",
+            "integrity": "sha512-+q91L65kypqklvlRFfXfdzUKyngQLOcwGhXQaLmVHv+d09LkNXuBuGxlofTFW42XMzu3giIcChchTsCNUjQ78A==",
+            "dev": true,
+            "requires": {
+                "import-local": "^2.0.0",
+                "jest-cli": "^24.1.0"
+            },
+            "dependencies": {
+                "jest-cli": {
+                    "version": "24.1.0",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.1.0.tgz",
+                    "integrity": "sha512-U/iyWPwOI0T1CIxVLtk/2uviOTJ/OiSWJSe8qt6X1VkbbgP+nrtLJlmT9lPBe4lK78VNFJtrJ7pttcNv/s7yCw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.0.0",
+                        "chalk": "^2.0.1",
+                        "exit": "^0.1.2",
+                        "glob": "^7.1.2",
+                        "graceful-fs": "^4.1.15",
+                        "import-local": "^2.0.0",
+                        "is-ci": "^2.0.0",
+                        "istanbul-api": "^2.0.8",
+                        "istanbul-lib-coverage": "^2.0.2",
+                        "istanbul-lib-instrument": "^3.0.1",
+                        "istanbul-lib-source-maps": "^3.0.1",
+                        "jest-changed-files": "^24.0.0",
+                        "jest-config": "^24.1.0",
+                        "jest-environment-jsdom": "^24.0.0",
+                        "jest-get-type": "^24.0.0",
+                        "jest-haste-map": "^24.0.0",
+                        "jest-message-util": "^24.0.0",
+                        "jest-regex-util": "^24.0.0",
+                        "jest-resolve-dependencies": "^24.1.0",
+                        "jest-runner": "^24.1.0",
+                        "jest-runtime": "^24.1.0",
+                        "jest-snapshot": "^24.1.0",
+                        "jest-util": "^24.0.0",
+                        "jest-validate": "^24.0.0",
+                        "jest-watcher": "^24.0.0",
+                        "jest-worker": "^24.0.0",
+                        "micromatch": "^3.1.10",
+                        "node-notifier": "^5.2.1",
+                        "p-each-series": "^1.0.0",
+                        "pirates": "^4.0.0",
+                        "prompts": "^2.0.1",
+                        "realpath-native": "^1.0.0",
+                        "rimraf": "^2.5.4",
+                        "slash": "^2.0.0",
+                        "string-length": "^2.0.0",
+                        "strip-ansi": "^5.0.0",
+                        "which": "^1.2.12",
+                        "yargs": "^12.0.2"
+                    }
+                }
+            }
+        },
+        "jest-changed-files": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.0.0.tgz",
+            "integrity": "sha512-nnuU510R9U+UX0WNb5XFEcsrMqriSiRLeO9KWDFgPrpToaQm60prfQYpxsXigdClpvNot5bekDY440x9dNGnsQ==",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0",
+                "throat": "^4.0.0"
+            }
+        },
+        "jest-config": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.1.0.tgz",
+            "integrity": "sha512-FbbRzRqtFC6eGjG5VwsbW4E5dW3zqJKLWYiZWhB0/4E5fgsMw8GODLbGSrY5t17kKOtCWb/Z7nsIThRoDpuVyg==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "babel-jest": "^24.1.0",
+                "chalk": "^2.0.1",
+                "glob": "^7.1.1",
+                "jest-environment-jsdom": "^24.0.0",
+                "jest-environment-node": "^24.0.0",
+                "jest-get-type": "^24.0.0",
+                "jest-jasmine2": "^24.1.0",
+                "jest-regex-util": "^24.0.0",
+                "jest-resolve": "^24.1.0",
+                "jest-util": "^24.0.0",
+                "jest-validate": "^24.0.0",
+                "micromatch": "^3.1.10",
+                "pretty-format": "^24.0.0",
+                "realpath-native": "^1.0.2"
+            }
+        },
+        "jest-diff": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.0.0.tgz",
+            "integrity": "sha512-XY5wMpRaTsuMoU+1/B2zQSKQ9RdE9gsLkGydx3nvApeyPijLA8GtEvIcPwISRCer+VDf9W1mStTYYq6fPt8ryA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1",
+                "diff-sequences": "^24.0.0",
+                "jest-get-type": "^24.0.0",
+                "pretty-format": "^24.0.0"
+            }
+        },
+        "jest-docblock": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.0.0.tgz",
+            "integrity": "sha512-KfAKZ4SN7CFOZpWg4i7g7MSlY0M+mq7K0aMqENaG2vHuhC9fc3vkpU/iNN9sOus7v3h3Y48uEjqz3+Gdn2iptA==",
+            "dev": true,
+            "requires": {
+                "detect-newline": "^2.1.0"
+            }
+        },
+        "jest-each": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.0.0.tgz",
+            "integrity": "sha512-gFcbY4Cu55yxExXMkjrnLXov3bWO3dbPAW7HXb31h/DNWdNc/6X8MtxGff8nh3/MjkF9DpVqnj0KsPKuPK0cpA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1",
+                "jest-get-type": "^24.0.0",
+                "jest-util": "^24.0.0",
+                "pretty-format": "^24.0.0"
+            }
+        },
+        "jest-environment-jsdom": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.0.0.tgz",
+            "integrity": "sha512-1YNp7xtxajTRaxbylDc2pWvFnfDTH5BJJGyVzyGAKNt/lEULohwEV9zFqTgG4bXRcq7xzdd+sGFws+LxThXXOw==",
+            "dev": true,
+            "requires": {
+                "jest-mock": "^24.0.0",
+                "jest-util": "^24.0.0",
+                "jsdom": "^11.5.1"
+            }
+        },
+        "jest-environment-node": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.0.0.tgz",
+            "integrity": "sha512-62fOFcaEdU0VLaq8JL90TqwI7hLn0cOKOl8vY2n477vRkCJRojiRRtJVRzzCcgFvs6gqU97DNqX5R0BrBP6Rxg==",
+            "dev": true,
+            "requires": {
+                "jest-mock": "^24.0.0",
+                "jest-util": "^24.0.0"
+            }
+        },
+        "jest-get-type": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.0.0.tgz",
+            "integrity": "sha512-z6/Eyf6s9ZDGz7eOvl+fzpuJmN9i0KyTt1no37/dHu8galssxz5ZEgnc1KaV8R31q1khxyhB4ui/X5ZjjPk77w==",
+            "dev": true
+        },
+        "jest-haste-map": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.0.0.tgz",
+            "integrity": "sha512-CcViJyUo41IQqttLxXVdI41YErkzBKbE6cS6dRAploCeutePYfUimWd3C9rQEWhX0YBOQzvNsC0O9nYxK2nnxQ==",
+            "dev": true,
+            "requires": {
+                "fb-watchman": "^2.0.0",
+                "graceful-fs": "^4.1.15",
+                "invariant": "^2.2.4",
+                "jest-serializer": "^24.0.0",
+                "jest-util": "^24.0.0",
+                "jest-worker": "^24.0.0",
+                "micromatch": "^3.1.10",
+                "sane": "^3.0.0"
+            }
+        },
+        "jest-jasmine2": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.1.0.tgz",
+            "integrity": "sha512-H+o76SdSNyCh9fM5K8upK45YTo/DiFx5w2YAzblQebSQmukDcoVBVeXynyr7DDnxh+0NTHYRCLwJVf3tC518wg==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.1.0",
+                "chalk": "^2.0.1",
+                "co": "^4.6.0",
+                "expect": "^24.1.0",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^24.0.0",
+                "jest-matcher-utils": "^24.0.0",
+                "jest-message-util": "^24.0.0",
+                "jest-snapshot": "^24.1.0",
+                "jest-util": "^24.0.0",
+                "pretty-format": "^24.0.0",
+                "throat": "^4.0.0"
+            }
+        },
+        "jest-leak-detector": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.0.0.tgz",
+            "integrity": "sha512-ZYHJYFeibxfsDSKowjDP332pStuiFT2xfc5R67Rjm/l+HFJWJgNIOCOlQGeXLCtyUn3A23+VVDdiCcnB6dTTrg==",
+            "dev": true,
+            "requires": {
+                "pretty-format": "^24.0.0"
+            }
+        },
+        "jest-matcher-utils": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.0.0.tgz",
+            "integrity": "sha512-LQTDmO+aWRz1Tf9HJg+HlPHhDh1E1c65kVwRFo5mwCVp5aQDzlkz4+vCvXhOKFjitV2f0kMdHxnODrXVoi+rlA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1",
+                "jest-diff": "^24.0.0",
+                "jest-get-type": "^24.0.0",
+                "pretty-format": "^24.0.0"
+            }
+        },
+        "jest-message-util": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.0.0.tgz",
+            "integrity": "sha512-J9ROJIwz/IeC+eV1XSwnRK4oAwPuhmxEyYx1+K5UI+pIYwFZDSrfZaiWTdq0d2xYFw4Xiu+0KQWsdsQpgJMf3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "chalk": "^2.0.1",
+                "micromatch": "^3.1.10",
+                "slash": "^2.0.0",
+                "stack-utils": "^1.0.1"
+            }
+        },
+        "jest-mock": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.0.0.tgz",
+            "integrity": "sha512-sQp0Hu5fcf5NZEh1U9eIW2qD0BwJZjb63Yqd98PQJFvf/zzUTBoUAwv/Dc/HFeNHIw1f3hl/48vNn+j3STaI7A==",
+            "dev": true
+        },
+        "jest-regex-util": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.0.0.tgz",
+            "integrity": "sha512-Jv/uOTCuC+PY7WpJl2mpoI+WbY2ut73qwwO9ByJJNwOCwr1qWhEW2Lyi2S9ZewUdJqeVpEBisdEVZSI+Zxo58Q==",
+            "dev": true
+        },
+        "jest-resolve": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.1.0.tgz",
+            "integrity": "sha512-TPiAIVp3TG6zAxH28u/6eogbwrvZjBMWroSLBDkwkHKrqxB/RIdwkWDye4uqPlZIXWIaHtifY3L0/eO5Z0f2wg==",
+            "dev": true,
+            "requires": {
+                "browser-resolve": "^1.11.3",
+                "chalk": "^2.0.1",
+                "realpath-native": "^1.0.0"
+            }
+        },
+        "jest-resolve-dependencies": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.1.0.tgz",
+            "integrity": "sha512-2VwPsjd3kRPu7qe2cpytAgowCObk5AKeizfXuuiwgm1a9sijJDZe8Kh1sFj6FKvSaNEfCPlBVkZEJa2482m/Uw==",
+            "dev": true,
+            "requires": {
+                "jest-regex-util": "^24.0.0",
+                "jest-snapshot": "^24.1.0"
+            }
+        },
+        "jest-runner": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.1.0.tgz",
+            "integrity": "sha512-CDGOkT3AIFl16BLL/OdbtYgYvbAprwJ+ExKuLZmGSCSldwsuU2dEGauqkpvd9nphVdAnJUcP12e/EIlnTX0QXg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.1.15",
+                "jest-config": "^24.1.0",
+                "jest-docblock": "^24.0.0",
+                "jest-haste-map": "^24.0.0",
+                "jest-jasmine2": "^24.1.0",
+                "jest-leak-detector": "^24.0.0",
+                "jest-message-util": "^24.0.0",
+                "jest-runtime": "^24.1.0",
+                "jest-util": "^24.0.0",
+                "jest-worker": "^24.0.0",
+                "source-map-support": "^0.5.6",
+                "throat": "^4.0.0"
+            }
+        },
+        "jest-runtime": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.1.0.tgz",
+            "integrity": "sha512-59/BY6OCuTXxGeDhEMU7+N33dpMQyXq7MLK07cNSIY/QYt2QZgJ7Tjx+rykBI0skAoigFl0A5tmT8UdwX92YuQ==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "babel-plugin-istanbul": "^5.1.0",
+                "chalk": "^2.0.1",
+                "convert-source-map": "^1.4.0",
+                "exit": "^0.1.2",
+                "fast-json-stable-stringify": "^2.0.0",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.1.15",
+                "jest-config": "^24.1.0",
+                "jest-haste-map": "^24.0.0",
+                "jest-message-util": "^24.0.0",
+                "jest-regex-util": "^24.0.0",
+                "jest-resolve": "^24.1.0",
+                "jest-snapshot": "^24.1.0",
+                "jest-util": "^24.0.0",
+                "jest-validate": "^24.0.0",
+                "micromatch": "^3.1.10",
+                "realpath-native": "^1.0.0",
+                "slash": "^2.0.0",
+                "strip-bom": "^3.0.0",
+                "write-file-atomic": "2.4.1",
+                "yargs": "^12.0.2"
+            }
+        },
+        "jest-serializer": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.0.0.tgz",
+            "integrity": "sha512-9FKxQyrFgHtx3ozU+1a8v938ILBE7S8Ko3uiAVjT8Yfi2o91j/fj81jacCQZ/Ihjiff/VsUCXVgQ+iF1XdImOw==",
+            "dev": true
+        },
+        "jest-snapshot": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.1.0.tgz",
+            "integrity": "sha512-th6TDfFqEmXvuViacU1ikD7xFb7lQsPn2rJl7OEmnfIVpnrx3QNY2t3PE88meeg0u/mQ0nkyvmC05PBqO4USFA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0",
+                "chalk": "^2.0.1",
+                "jest-diff": "^24.0.0",
+                "jest-matcher-utils": "^24.0.0",
+                "jest-message-util": "^24.0.0",
+                "jest-resolve": "^24.1.0",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^24.0.0",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-util": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.0.0.tgz",
+            "integrity": "sha512-QxsALc4wguYS7cfjdQSOr5HTkmjzkHgmZvIDkcmPfl1ib8PNV8QUWLwbKefCudWS0PRKioV+VbQ0oCUPC691fQ==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0",
+                "chalk": "^2.0.1",
+                "graceful-fs": "^4.1.15",
+                "is-ci": "^2.0.0",
+                "jest-message-util": "^24.0.0",
+                "mkdirp": "^0.5.1",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-validate": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.0.0.tgz",
+            "integrity": "sha512-vMrKrTOP4BBFIeOWsjpsDgVXATxCspC9S1gqvbJ3Tnn/b9ACsJmteYeVx9830UMV28Cob1RX55x96Qq3Tfad4g==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "chalk": "^2.0.1",
+                "jest-get-type": "^24.0.0",
+                "leven": "^2.1.0",
+                "pretty-format": "^24.0.0"
+            }
+        },
+        "jest-watcher": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.0.0.tgz",
+            "integrity": "sha512-GxkW2QrZ4YxmW1GUWER05McjVDunBlKMFfExu+VsGmXJmpej1saTEKvONdx5RJBlVdpPI5x6E3+EDQSIGgl53g==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.1",
+                "jest-util": "^24.0.0",
+                "string-length": "^2.0.0"
+            }
+        },
+        "jest-worker": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.0.0.tgz",
+            "integrity": "sha512-s64/OThpfQvoCeHG963MiEZOAAxu8kHsaL/rCMF7lpdzo7vgF0CtPml9hfguOMgykgH/eOm4jFP4ibfHLruytg==",
+            "dev": true,
+            "requires": {
+                "merge-stream": "^1.0.1",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+            "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "jsdom": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+            "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.0",
+                "acorn": "^5.5.3",
+                "acorn-globals": "^4.1.0",
+                "array-equal": "^1.0.0",
+                "cssom": ">= 0.3.2 < 0.4.0",
+                "cssstyle": "^1.0.0",
+                "data-urls": "^1.0.0",
+                "domexception": "^1.0.1",
+                "escodegen": "^1.9.1",
+                "html-encoding-sniffer": "^1.0.2",
+                "left-pad": "^1.3.0",
+                "nwsapi": "^2.0.7",
+                "parse5": "4.0.0",
+                "pn": "^1.1.0",
+                "request": "^2.87.0",
+                "request-promise-native": "^1.0.5",
+                "sax": "^1.2.4",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.3.4",
+                "w3c-hr-time": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.3",
+                "whatwg-mimetype": "^2.1.0",
+                "whatwg-url": "^6.4.1",
+                "ws": "^5.2.0",
+                "xml-name-validator": "^3.0.0"
+            }
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "json5": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+            "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "kind-of": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "dev": true
+        },
+        "kleur": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.2.tgz",
+            "integrity": "sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q==",
+            "dev": true
+        },
+        "lcid": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+            "dev": true,
+            "requires": {
+                "invert-kv": "^2.0.0"
+            }
+        },
+        "left-pad": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+            "dev": true
+        },
+        "leven": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            }
+        },
+        "load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
+            "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "dev": true
+        },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
+        "makeerror": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
+            "requires": {
+                "tmpl": "1.0.x"
+            }
+        },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "^1.0.0"
+            }
+        },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "mem": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+            "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+            "dev": true,
+            "requires": {
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^1.0.0",
+                "p-is-promise": "^2.0.0"
+            }
+        },
+        "merge": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+            "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+            "dev": true
         },
         "merge-descriptors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
             "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
         },
+        "merge-stream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.1"
+            }
+        },
         "methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+        },
+        "micromatch": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+            }
         },
         "mime": {
             "version": "1.4.1",
@@ -226,15 +3365,258 @@
                 "mime-db": "~1.37.0"
             }
         },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+            "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+            "dev": true
+        },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
+            }
+        },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
+        "nan": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+            "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+            "dev": true,
+            "optional": true
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            }
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
         "negotiator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
             "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
+        "node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
+        },
+        "node-modules-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+            "dev": true
+        },
+        "node-notifier": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+            "dev": true,
+            "requires": {
+                "growly": "^1.3.0",
+                "is-wsl": "^1.1.0",
+                "semver": "^5.5.0",
+                "shellwords": "^0.1.1",
+                "which": "^1.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "dev": true
+                }
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "^1.0.1"
+            }
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "^2.0.0"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "nwsapi": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
+            "integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "object-keys": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+            "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+            "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.0"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
         },
         "on-finished": {
             "version": "2.3.0",
@@ -244,15 +3626,146 @@
                 "ee-first": "1.1.1"
             }
         },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+                    "dev": true
+                }
+            }
+        },
+        "os-locale": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
+            }
+        },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
+        "p-each-series": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+            "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+            "dev": true,
+            "requires": {
+                "p-reduce": "^1.0.0"
+            }
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-is-promise": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+            "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+            "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-reduce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+            "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+            "dev": true
+        },
+        "p-try": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+            "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+            "dev": true
+        },
         "packet-reader": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
             "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
         },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "dev": true,
+            "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            }
+        },
+        "parse5": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+            "dev": true
+        },
         "parseurl": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
             "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
         },
         "passport": {
             "version": "0.4.0",
@@ -276,15 +3789,54 @@
             "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
             "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
         },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
         "path-to-regexp": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
             "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
+        "path-type": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
         "pause": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
             "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
         },
         "pg": {
             "version": "7.8.0",
@@ -335,6 +3887,42 @@
                 "split": "^1.0.0"
             }
         },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "dev": true
+        },
+        "pirates": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+            "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+            "dev": true,
+            "requires": {
+                "node-modules-regexp": "^1.0.0"
+            }
+        },
+        "pkg-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+            "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0"
+            }
+        },
+        "pn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
         "postgres-array": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -358,6 +3946,38 @@
                 "xtend": "^4.0.0"
             }
         },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "pretty-format": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.0.0.tgz",
+            "integrity": "sha512-LszZaKG665djUcqg5ZQq+XzezHLKrxsA86ZABTozp+oNhkdqa+tG2dX4qa6ERl5c/sRDrAa3lHmwnvKoP+OG/g==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^4.0.0",
+                "ansi-styles": "^3.2.0"
+            }
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
+        },
+        "prompts": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.3.tgz",
+            "integrity": "sha512-H8oWEoRZpybm6NV4to9/1limhttEo13xK62pNvn2JzY0MA03p7s0OjtmhXyon3uJmxiJJVSuUwEJFFssI3eBiQ==",
+            "dev": true,
+            "requires": {
+                "kleur": "^3.0.2",
+                "sisteransi": "^1.0.0"
+            }
+        },
         "proxy-addr": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
@@ -366,6 +3986,28 @@
                 "forwarded": "~0.1.2",
                 "ipaddr.js": "1.8.0"
             }
+        },
+        "psl": {
+            "version": "1.1.31",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+            "dev": true
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
         },
         "qs": {
             "version": "6.5.2",
@@ -388,15 +4030,258 @@
                 "unpipe": "1.0.0"
             }
         },
+        "read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+            "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "realpath-native": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+            "dev": true,
+            "requires": {
+                "util.promisify": "^1.0.0"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "request": {
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                }
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.11"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.2",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-cwd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^3.0.0"
+            }
+        },
+        "resolve-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+            "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "rsvp": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+            "dev": true
+        },
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "sane": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-3.1.0.tgz",
+            "integrity": "sha512-G5GClRRxT1cELXfdAq7UKtUsv8q/ZC5k8lQGmjEm4HcAl3HzBy68iglyNCmw4+0tiXPCBZntslHlRhbnsSws+Q==",
+            "dev": true,
+            "requires": {
+                "anymatch": "^2.0.0",
+                "capture-exit": "^1.2.0",
+                "exec-sh": "^0.2.0",
+                "execa": "^1.0.0",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^1.2.3",
+                "micromatch": "^3.1.4",
+                "minimist": "^1.1.1",
+                "walker": "~1.0.5",
+                "watch": "~0.18.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
         },
         "semver": {
             "version": "4.3.2",
@@ -434,10 +4319,260 @@
                 "send": "0.16.2"
             }
         },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
         "setprototypeof": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
             "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "shellwords": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "sisteransi": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+            "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+            "dev": true
+        },
+        "slash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+            "dev": true
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
+            "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.2.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-resolve": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "dev": true,
+            "requires": {
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+            "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
+        },
+        "spdx-correct": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+            "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+            "dev": true
         },
         "split": {
             "version": "1.0.1",
@@ -447,15 +4582,345 @@
                 "through": "2"
             }
         },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "stack-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+            "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+            "dev": true
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
         "statuses": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
             "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
+        },
+        "string-length": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+            "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+            "dev": true,
+            "requires": {
+                "astral-regex": "^1.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+            "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^4.0.0"
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "superagent": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+            "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+            "dev": true,
+            "requires": {
+                "component-emitter": "^1.2.0",
+                "cookiejar": "^2.1.0",
+                "debug": "^3.1.0",
+                "extend": "^3.0.0",
+                "form-data": "^2.3.1",
+                "formidable": "^1.2.0",
+                "methods": "^1.1.1",
+                "mime": "^1.4.1",
+                "qs": "^6.5.1",
+                "readable-stream": "^2.3.5"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "supertest": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.4.2.tgz",
+            "integrity": "sha512-WZWbwceHUo2P36RoEIdXvmqfs47idNNZjCuJOqDz6rvtkk8ym56aU5oglORCpPeXGxT7l9rkJ41+O1lffQXYSA==",
+            "dev": true,
+            "requires": {
+                "methods": "^1.1.2",
+                "superagent": "^3.8.3"
+            }
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "symbol-tree": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "dev": true
+        },
+        "test-exclude": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
+            "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+            "dev": true,
+            "requires": {
+                "arrify": "^1.0.1",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^1.0.1"
+            }
+        },
+        "throat": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+            "dev": true
+        },
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+            }
+        },
+        "tough-cookie": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "dev": true,
+            "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            }
+        },
+        "tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
         },
         "type-is": {
             "version": "1.6.16",
@@ -466,25 +4931,399 @@
                 "mime-types": "~2.1.18"
             }
         },
+        "uglify-js": {
+            "version": "3.4.9",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+            "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "commander": "~2.17.1",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
+                    }
+                }
+            }
+        },
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                }
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "util.promisify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
         },
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
         },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "w3c-hr-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+            "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "^0.1.2"
+            }
+        },
+        "walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
+            "requires": {
+                "makeerror": "1.0.x"
+            }
+        },
+        "watch": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+            "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+            "dev": true,
+            "requires": {
+                "exec-sh": "^0.2.0",
+                "minimist": "^1.2.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "webidl-conversions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true
+        },
+        "whatwg-encoding": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.24"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
+            }
+        },
+        "whatwg-mimetype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+            "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+            "dev": true,
+            "requires": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+            }
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write-file-atomic": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+            "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "ws": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+            "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+            "dev": true,
+            "requires": {
+                "async-limiter": "~1.0.0"
+            }
+        },
+        "xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "dev": true
+        },
+        "yargs": {
+            "version": "12.0.5",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+            "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+            "dev": true,
+            "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^3.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1 || ^4.0.0",
+                "yargs-parser": "^11.1.1"
+            }
+        },
+        "yargs-parser": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+            "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,17 @@
         "url": "https://github.com/warblerorg/warbler-server"
     },
     "version": "0.0.1",
+    "scripts": {
+        "test": "jest"
+    },
     "dependencies": {
         "express": "4.16.4",
         "passport": "^0.4.0",
         "passport-local": "^1.0.0",
         "pg": "^7.8.0"
+    },
+    "devDependencies": {
+        "jest": "^24.1.0",
+        "supertest": "^3.4.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "devDependencies": {
         "jest": "^24.1.0",
         "supertest": "^3.4.2"
+    },
+    "jest": {
+        "testEnvironment": "node"
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     },
     "version": "0.0.1",
     "scripts": {
-        "test": "jest"
+        "test": "jest",
+        "start": "node index.js"
     },
     "dependencies": {
         "express": "4.16.4",

--- a/test/api/comments.spec.js
+++ b/test/api/comments.spec.js
@@ -14,8 +14,14 @@ const author = {
     avatar_url: ''
 };
 
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
+
 describe('GET /comments/{thread_id}', () => {
     // TODO mock the existing thread
+
+    // For some reason this is needed for the
+    // first 2 test suites to work properly
+    beforeAll(() => wait(1000));
 
     test('should have 404 status for unknown thread', async () => {
         await request(app)

--- a/test/api/comments.spec.js
+++ b/test/api/comments.spec.js
@@ -18,13 +18,13 @@ describe('GET /comments/{thread_id}', () => {
     // TODO mock the existing thread
 
     test('should have 404 status for unknown thread', async () => {
-        await request(server)
+        await request(app)
             .get(`/v1/comments/${fakeThreadId}`)
             .expect(404);
     });
 
     test('should have 200 status for known thread', async () => {
-        const res = await request(server)
+        const res = await request(app)
             .get(`/v1/comments/${exitingThreadId}`)
             .expect('Content-Type', /json/)
             .expect(200);
@@ -38,7 +38,7 @@ describe('POST /comments/{thread_id}', () => {
     // TODO mock the existing thread
 
     test('should have 404 status for unknown thread', async () => {
-        await request(server)
+        await request(app)
             .post(`/v1/comments/${fakeThreadId}`)
             .send('Hello world')
             .set('Content-Type', 'text/plain')
@@ -47,7 +47,7 @@ describe('POST /comments/{thread_id}', () => {
     });
 
     test('should have 401 status for no authorization', async () => {
-        await request(server)
+        await request(app)
             .post(`/v1/comments/${exitingThreadId}`)
             .send('Hello world')
             .set('Content-Type', 'text/plain')
@@ -63,7 +63,7 @@ describe('POST /comments/{thread_id}', () => {
 
         for (const [type, content] of commentTypes) {
             test(`should accept ${type}`, async () => {
-                const res = await request(server)
+                const res = await request(app)
                     .post(`/v1/comments/${exitingThreadId}`)
                     .set('Content-Type', type)
                     .set('Authorization', bearer)
@@ -81,7 +81,7 @@ describe('POST /comments/{thread_id}', () => {
     });
 
     describe('should convert markdown', async () => {
-        const res = await request(server)
+        const res = await request(app)
             .post(`/v1/comments/${exitingThreadId}`)
             .set('Content-Type', 'text/plain')
             .set('Authorization', bearer)
@@ -91,7 +91,7 @@ describe('POST /comments/{thread_id}', () => {
     });
 
     describe('should remove XSS vectors', async () => {
-        const res = await request(server)
+        const res = await request(app)
             .post(`/v1/comments/${exitingThreadId}`)
             .set('Content-Type', 'text/plain')
             .set('Authorization', bearer)
@@ -107,7 +107,7 @@ describe('PUT /comments/{thread_id}/{comment_id}', () => {
     // TODO mock the existing thread
 
     test('should have 404 status for unknown thread', async () => {
-        await request(server)
+        await request(app)
             .put(`/v1/comments/${fakeThreadId}/0`)
             .send('Hello world')
             .set('Content-Type', 'text/plain')
@@ -116,7 +116,7 @@ describe('PUT /comments/{thread_id}/{comment_id}', () => {
     });
 
     test('should have 404 status for unknown comment', async () => {
-        await request(server)
+        await request(app)
             .put(`/v1/comments/${fakeCommentId}`)
             .send('Hello world')
             .set('Content-Type', 'text/plain')
@@ -125,7 +125,7 @@ describe('PUT /comments/{thread_id}/{comment_id}', () => {
     });
 
     test('should have 401 status for no authorization', async () => {
-        await request(server)
+        await request(app)
             .put(`/v1/comments/${existingCommentId}`)
             .send('Hello world')
             .set('Content-Type', 'text/plain')
@@ -141,7 +141,7 @@ describe('PUT /comments/{thread_id}/{comment_id}', () => {
 
         for (const [type, content] of commentTypes) {
             test(`should accept ${type}`, async () => {
-                const res = await request(server)
+                const res = await request(app)
                     .put(`/v1/comments/${existingCommentId}`)
                     .set('Content-Type', type)
                     .set('Authorization', bearer)
@@ -159,7 +159,7 @@ describe('PUT /comments/{thread_id}/{comment_id}', () => {
     });
 
     describe('should convert markdown', async () => {
-        const res = await request(server)
+        const res = await request(app)
             .put(`/v1/comments/${existingCommentId}`)
             .set('Content-Type', 'text/plain')
             .set('Authorization', bearer)
@@ -169,7 +169,7 @@ describe('PUT /comments/{thread_id}/{comment_id}', () => {
     });
 
     describe('should remove XSS vectors', async () => {
-        const res = await request(server)
+        const res = await request(app)
             .put(`/v1/comments/${existingCommentId}`)
             .set('Content-Type', 'text/plain')
             .set('Authorization', bearer)
@@ -185,7 +185,7 @@ describe('DELETE /comments/{thread_id}/{comment_id}', () => {
     // TODO mock the existing thread
 
     test('should have 404 status for unknown thread', async () => {
-        await request(server)
+        await request(app)
             .delete(`/v1/comments/${fakeThreadId}/0`)
             .set('Content-Type', 'text/plain')
             .set('Authorization', bearer)
@@ -193,7 +193,7 @@ describe('DELETE /comments/{thread_id}/{comment_id}', () => {
     });
 
     test('should have 404 status for unknown comment', async () => {
-        await request(server)
+        await request(app)
             .delete(`/v1/comments/${fakeCommentId}`)
             .set('Content-Type', 'text/plain')
             .set('Authorization', bearer)
@@ -201,14 +201,14 @@ describe('DELETE /comments/{thread_id}/{comment_id}', () => {
     });
 
     test('should have 401 status for no authorization', async () => {
-        await request(server)
+        await request(app)
             .put(`/v1/comments/${existingCommentId}`)
             .set('Content-Type', 'text/plain')
             .expect(401);
     });
 
     describe('should delete comment', async () => {
-        await request(server)
+        await request(app)
             .put(`/v1/comments/${exitingThreadId}/4321`)
             .set('Content-Type', 'text/plain')
             .set('Authorization', bearer)

--- a/test/api/comments.spec.js
+++ b/test/api/comments.spec.js
@@ -1,0 +1,217 @@
+const request = require('supertest');
+const { server } = require('../../app');
+
+const exitingThreadId = 'existing-12ad3';
+const fakeThreadId = 'does-not-exist-935sr';
+const existingCommentId = 'existing-12ad3/1234';
+const fakeCommentId = 'existing-12ad3/1000';
+
+const bearer = 'Bearer 2312sd.3432re3d.4324324';
+const author = {
+    username: 'drwho',
+    name: 'John Smith',
+    website: 'https://tardis.net',
+    avatar_url: ''
+};
+
+describe('GET /comments/{thread_id}', () => {
+    // TODO mock the existing thread
+
+    test('should have 404 status for unknown thread', async () => {
+        await request(server)
+            .get(`/v1/comments/${fakeThreadId}`)
+            .expect(404);
+    });
+
+    test('should have 200 status for known thread', async () => {
+        const res = await request(server)
+            .get(`/v1/comments/${exitingThreadId}`)
+            .expect('Content-Type', /json/)
+            .expect(200);
+        expect(res.body).toBeInstanceOf(Object);
+    });
+
+    // TODO test the body
+});
+
+describe('POST /comments/{thread_id}', () => {
+    // TODO mock the existing thread
+
+    test('should have 404 status for unknown thread', async () => {
+        await request(server)
+            .post(`/v1/comments/${fakeThreadId}`)
+            .send('Hello world')
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .expect(404);
+    });
+
+    test('should have 401 status for no authorization', async () => {
+        await request(server)
+            .post(`/v1/comments/${exitingThreadId}`)
+            .send('Hello world')
+            .set('Content-Type', 'text/plain')
+            .expect(401);
+    });
+
+    describe('should accept various MIME types', () => {
+        const commentTypes = new Map()
+            .set('application/json', { content: 'Hello world' })
+            .set('multipart/form-data', 'content=Hello%20world')
+            .set('application/x-www-form-urlencoded', 'content=Hello%20world')
+            .set('text/plain', 'Hello world');
+
+        for (const [type, content] of commentTypes) {
+            test(`should accept ${type}`, async () => {
+                const res = await request(server)
+                    .post(`/v1/comments/${exitingThreadId}`)
+                    .set('Content-Type', type)
+                    .set('Authorization', bearer)
+                    .send(content)
+                    .expect(200);
+                expect(res.body).toEqual({
+                    thread_id: exitingThreadId,
+                    comment_id: expect.any(Number),
+                    parent_id: null,
+                    author,
+                    content: 'Hello world'
+                });
+            });
+        }
+    });
+
+    describe('should convert markdown', async () => {
+        const res = await request(server)
+            .post(`/v1/comments/${exitingThreadId}`)
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .send('**Hello** _world_!')
+            .expect(200);
+        expect(res.body.content).toBe('<strong>Hello</strong> <em>world</em>!');
+    });
+
+    describe('should remove XSS vectors', async () => {
+        const res = await request(server)
+            .post(`/v1/comments/${exitingThreadId}`)
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .send(
+                `<img onload="alert('Evil code')" src="https://example.com"><script>alert('Hello bad world')</script><style>*{display:none}</style>`
+            )
+            .expect(200);
+        expect(res.body.content).toBe('<img src="https://example.com">');
+    });
+});
+
+describe('PUT /comments/{thread_id}/{comment_id}', () => {
+    // TODO mock the existing thread
+
+    test('should have 404 status for unknown thread', async () => {
+        await request(server)
+            .put(`/v1/comments/${fakeThreadId}/0`)
+            .send('Hello world')
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .expect(404);
+    });
+
+    test('should have 404 status for unknown comment', async () => {
+        await request(server)
+            .put(`/v1/comments/${fakeCommentId}`)
+            .send('Hello world')
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .expect(404);
+    });
+
+    test('should have 401 status for no authorization', async () => {
+        await request(server)
+            .put(`/v1/comments/${existingCommentId}`)
+            .send('Hello world')
+            .set('Content-Type', 'text/plain')
+            .expect(401);
+    });
+
+    describe('should accept various MIME types', () => {
+        const commentTypes = new Map()
+            .set('application/json', { content: 'Hello world' })
+            .set('multipart/form-data', 'content=Hello%20world')
+            .set('application/x-www-form-urlencoded', 'content=Hello%20world')
+            .set('text/plain', 'Hello world');
+
+        for (const [type, content] of commentTypes) {
+            test(`should accept ${type}`, async () => {
+                const res = await request(server)
+                    .put(`/v1/comments/${existingCommentId}`)
+                    .set('Content-Type', type)
+                    .set('Authorization', bearer)
+                    .send(content)
+                    .expect(200);
+                expect(res.body).toEqual({
+                    thread_id: exitingThreadId,
+                    comment_id: 1234,
+                    parent_id: null,
+                    author,
+                    content: 'Hello world'
+                });
+            });
+        }
+    });
+
+    describe('should convert markdown', async () => {
+        const res = await request(server)
+            .put(`/v1/comments/${existingCommentId}`)
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .send('**Hello** _world_!')
+            .expect(200);
+        expect(res.body.content).toBe('<strong>Hello</strong> <em>world</em>!');
+    });
+
+    describe('should remove XSS vectors', async () => {
+        const res = await request(server)
+            .put(`/v1/comments/${existingCommentId}`)
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .send(
+                `<img onload="alert('Evil code')" src="https://example.com"><script>alert('Hello bad world')</script><style>*{display:none}</style>`
+            )
+            .expect(200);
+        expect(res.body.content).toBe('<img src="https://example.com">');
+    });
+});
+
+describe('DELETE /comments/{thread_id}/{comment_id}', () => {
+    // TODO mock the existing thread
+
+    test('should have 404 status for unknown thread', async () => {
+        await request(server)
+            .delete(`/v1/comments/${fakeThreadId}/0`)
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .expect(404);
+    });
+
+    test('should have 404 status for unknown comment', async () => {
+        await request(server)
+            .delete(`/v1/comments/${fakeCommentId}`)
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .expect(404);
+    });
+
+    test('should have 401 status for no authorization', async () => {
+        await request(server)
+            .put(`/v1/comments/${existingCommentId}`)
+            .set('Content-Type', 'text/plain')
+            .expect(401);
+    });
+
+    describe('should delete comment', async () => {
+        await request(server)
+            .put(`/v1/comments/${exitingThreadId}/4321`)
+            .set('Content-Type', 'text/plain')
+            .set('Authorization', bearer)
+            .expect(200);
+    });
+});

--- a/test/api/comments.spec.js
+++ b/test/api/comments.spec.js
@@ -1,5 +1,5 @@
 const request = require('supertest');
-const { server } = require('../../app');
+const { app } = require('../../app');
 
 const exitingThreadId = 'existing-12ad3';
 const fakeThreadId = 'does-not-exist-935sr';


### PR DESCRIPTION
Doing some TDD 😮 

Adds `jest` and `supertest`, along with some integration tests for the [comment API routes](https://warblerorg.github.io/warbler-api/#/comment).

These tests don't pass yet since the corresponding routes haven't been implemented.